### PR TITLE
Some changes

### DIFF
--- a/R/extractESS.R
+++ b/R/extractESS.R
@@ -2,14 +2,14 @@
 extractESS <- function(trait, id) {
   # get beast log
   log <-
-    parse_beast_tracelog_file(
+    tracerer::parse_beast_tracelog_file(
       paste0("temp/log_", paste0(trait, "_", id), ".log")
     )
   # extract ESS
   bind_cols(
     tibble(trait = trait),
-    calc_esses(
-      remove_burn_ins(log, burn_in_fraction = 0.1), sample_interval = 1000
+    tracerer::calc_esses(
+      tracerer::remove_burn_ins(log, burn_in_fraction = 0.1), sample_interval = 1000
     )
   )
 }

--- a/R/fitBEAST.R
+++ b/R/fitBEAST.R
@@ -8,7 +8,7 @@ fitBEAST <- function(fileXML, trait, id, numThreads = 1) {
   command <- 
     paste0(
       # run beast
-      BEAST_COMMAND, " ",
+      BEAST_COMMAND, " ",   # BEAST_COMMAND is injected by targets here from global namespace
       # number of threads
       "-threads ", numThreads, " ",
       # json file

--- a/R/fitBEAST.R
+++ b/R/fitBEAST.R
@@ -8,7 +8,7 @@ fitBEAST <- function(fileXML, trait, id, numThreads = 1) {
   command <- 
     paste0(
       # run beast
-      "BEAST.v2.7.7.Windows/BEAST/bat/beast.bat ",
+      BEAST_COMMAND, " ",
       # number of threads
       "-threads ", numThreads, " ",
       # json file

--- a/_targets.R
+++ b/_targets.R
@@ -6,6 +6,11 @@ library(tarchetypes)
 library(tidyverse)
 tar_source()
 
+BEAST_COMMAND <- 'BEAST.v2.7.7.Windows/BEAST/bat/beast.bat'
+BEAST_COMMAND <- 'beast' # -beagle -beagle_SSE'
+
+NUMBER_OF_VALIDATIONS <- 50
+
 # set targets options
 tar_option_set(
   packages = c("ape","brms","dplyr","cowplot","ggplot2","ggtree","ggtreeExtra",
@@ -75,7 +80,7 @@ list(
   ### 2. Imputations
   
   # ids to loop over (0 = main, 1:n = validations)
-  tar_target(id, 0:50),
+  tar_target(id, 0:NUMBER_OF_VALIDATIONS),
   ## run imputations
   impTargets,
   # combine results

--- a/xml/imputeTipsBEAST_multiTree_strictClock.xml
+++ b/xml/imputeTipsBEAST_multiTree_strictClock.xml
@@ -13375,7 +13375,7 @@ spec="Alignment">
             <log idref="prior"/>
         </logger>
         <logger id="treelog.t:tree" spec="Logger" fileName="$(treesOutFile)" logEvery="500000" mode="tree">
-            <log id="TreeWithMetaDataLogger.t:tree" spec="beast.base.evolution.TreeWithMetaDataLogger" tree="@Tree.t:tree"/>
+            <log id="TreeWithMetaDataLogger.t:tree" spec="beast.base.evolution.TreeWithMetaDataLogger" dp="8" tree="@Tree.t:tree"/>
         </logger>
         <logger id="treeWithTraitLogger.gbTrait" spec="Logger" fileName="$(imputationsFile)" logEvery="5000" mode="tree">
             <log id="treeWithTraitLoggerItem.t:tree" spec="beastclassic.evolution.tree.TreeWithTraitLogger" tree="@Tree.t:tree">


### PR DESCRIPTION
1. Make BEAST_COMMAND a high level setting. Looks like `targets` injects global variables into namespace.
2. explicitly namespacing from tracerer (as I ran into issues running this function outside the pipeline).
3. add a decimal place argument to beast xml to stop one warning and reduce size of output file (8 decimal places should be enough for anyone)