### PR TITLE
Some minor tweaks

### DIFF
--- a/R/getImputations.R
+++ b/R/getImputations.R
@@ -54,7 +54,10 @@ getImputations <- function(d, mcc, treesSubset, fileTrees,
     rename(Language_ID = label) %>%
     dplyr::select(Trait, id, everything()) %>%
     left_join(ess, by = "Trait")
-  # clean up files after all computation is finished
-  cleanUpFiles(trait, id)
+  
+  # clean up files after all computation is finished, unless KEEP_BEAST_FILES is set.
+  if (!exists("KEEP_BEAST_FILES") || !isTRUE(KEEP_BEAST_FILES)) {
+    cleanUpFiles(trait, id)
+  }
   return(out)
 }

--- a/R/plotTraitLoss.R
+++ b/R/plotTraitLoss.R
@@ -2,8 +2,6 @@ plotTraitLoss <- function(endanger, imp) {
   # join imputations and endangerment probabilities
   d <-
     endanger %>%
-    # grambank traits only
-    filter(str_starts(trait, fixed("GB"))) %>%
     # calculate probabilities of NOT being sleeping (EGIDS >= 9)
     transmute(
       glottocode, EGIDS,

--- a/_targets.R
+++ b/_targets.R
@@ -4,12 +4,23 @@ library(crew)
 library(targets)
 library(tarchetypes)
 library(tidyverse)
+
+tar_option_set(
+  controller = crew_controller_local(workers = 8)
+)
+
 tar_source()
 
 BEAST_COMMAND <- 'BEAST.v2.7.7.Windows/BEAST/bat/beast.bat'
 BEAST_COMMAND <- 'beast' # -beagle -beagle_SSE'
 
-NUMBER_OF_VALIDATIONS <- 50
+# keep beast files or not:
+#   if TRUE then all xml/log/trees files are kept (for debugging purposes).
+#   otherwise they're removed if KEEP_BEAST_FILES is not set or is set to FALSE
+KEEP_BEAST_FILES <- FALSE
+
+
+NUMBER_OF_VALIDATIONS <- 2
 
 # set targets options
 tar_option_set(
@@ -19,7 +30,7 @@ tar_option_set(
 
 # get binary grambank traits
 binaryGBTraits <- 
-  read_csv(
+  readr::read_csv(
     paste0(
       # Grambank version 1.0.3
       "https://raw.githubusercontent.com/grambank/grambank/",
@@ -33,7 +44,9 @@ binaryGBTraits <-
 # replace multistate variables with binarised variables.
 # multistate_parameters and binary_parameters are set in binariseGB.R
 binaryGBTraits <- binaryGBTraits[!binaryGBTraits %in% multistate_parameters]
-binaryGBTraits <- c(binaryGBTraits, binary_parameters)
+binaryGBTraits <- c(binaryGBTraits, binary_parameters) |> unique()
+
+#print("DEBUG"); binaryGBTraits <- binaryGBTraits[1:3]
 
 
 # targets for imputations


### PR DESCRIPTION
- adds a parameter `KEEP_BEAST_FILES` which will keep beast files if set (useful for debugging, but overkill otherwise)
- fixes a minor issue with some traits appearing twice in `binaryGBTraits`
- removes a filter that only keeps traits starting with `GB.*` in plotTraitLoss.R -- this was removing all traits.